### PR TITLE
Add load-grunt-tasks to project

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,12 +59,7 @@ module.exports = function (grunt) {
     }
   });
 
-  grunt.loadNpmTasks('grunt-closurecompiler');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-exec');
-  grunt.loadNpmTasks('grunt-mocha-test');
-  grunt.loadNpmTasks('grunt-contrib-copy');
+  require('load-grunt-tasks')(grunt);
 
   grunt.registerTask('compile', ['closurecompiler:compile']);
   grunt.registerTask('debug', ['closurecompiler:debug']);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "promises-aplus-tests": "~2.0.4",
     "expect.js": "~0.3.1",
     "grunt-mocha-test": "^0.10.2",
-    "grunt-contrib-copy": "^0.5.0"
+    "grunt-contrib-copy": "^0.5.0",
+    "load-grunt-tasks": "^3.0.0"
   },
   "keywords": ["promise", "promises", "promise-aplus", "promises-aplus", "closure compiler", "async", "deferred", "await", "defer"],
   "scripts": {


### PR DESCRIPTION
Just a little simpler way of loading Grunt tasks.

---

@bramstein adding a new dependency to `package.json`(alphabetizing dependencies, newlines for keywords etc.), I didn't want to pollute this PR but if you want I'll submit another PR with those `package.json` modifications.
